### PR TITLE
Add a Travis-CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+matrix:
+    include:
+        - os: linux
+          env: PYTHON="3.4" MINICONDA_OS="Linux"
+        - os: linux
+          env: PYTHON="3.5" MINICONDA_OS="Linux"
+        - os: osx
+          env: PYTHON="3.4" MINICONDA_OS="MacOSX"
+        - os: osx
+          env: PYTHON="3.5" MINICONDA_OS="MacOSX"
+
+before_install:
+    URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh";
+    wget "${URL}" -O miniconda.sh;
+    bash miniconda.sh -b -p $HOME/miniconda;
+    export PATH="$HOME/miniconda/bin:$PATH";
+    hash -r;
+    conda config --set always_yes yes --set changeps1 no;
+    conda update -q conda;
+    conda info -a;
+install:
+    conda create -q -n test_env python=${PYTHON} numpy cython freetype;
+    source activate test_env;
+    python setup.py install;
+script:
+    python -c 'import pyagg';
+


### PR DESCRIPTION
With Travis CI, we'll be able to (more often than not :wink:) avoid breaking the library when making changes. Once a test suite is added, that can be run too.

In order to fully enable Travis CI for this repository, you (@erikhvatum) will need to sign up for the service (it's free) and enable testing for `erikhvatum/pyagg`.
